### PR TITLE
dotCMS/core#21111 RESEARCH: how to keep dotcms images in older/static versions of the documentation

### DIFF
--- a/components/mdx-components/ImageMarkdown.tsx
+++ b/components/mdx-components/ImageMarkdown.tsx
@@ -7,6 +7,7 @@ export const ImageMarkdown = (props: {
     height?: string;
 }): JSX.Element => {
     const myLoader = ({ src }) => src;
+
     return (
         <>
             {props.width && props.height ? (

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "h2x-core": "^1.1.1",
         "h2x-plugin-jsx": "^1.2.0",
         "html-entities": "^2.3.2",
+        "image-downloader": "^4.1.0",
         "next": "^10.1.2",
         "next-mdx-remote": "^2.1.3",
         "npm-check-updates": "^11.3.0",

--- a/pages/[urlTitle].tsx
+++ b/pages/[urlTitle].tsx
@@ -6,6 +6,7 @@ import styles from '@styles/urlTitle.module.css';
 
 // mdx custom Plugins
 import DotCodeMultiline from '@plugins/DotCodeMultiline';
+import DownloadImages from '@plugins/DownloadImages';
 import DotCodeTab from '@plugins/DotCodeTab';
 import DotDecodeHtml from '@plugins/DotDecodeHtml';
 import DotHtmlToJsxRemark from '@plugins/DotHtmlToJsxRemark';
@@ -58,6 +59,7 @@ const componentsUI: MDXProviderComponentsProp = {
 };
 
 const UrlTitle = ({ data, error, showSideToc, source, toc = [] }: PageData): JSX.Element => {
+
     const content = hydrate(source, { components: componentsUI });
     // ---- Table Of Content Active Item
     const [tocActive, setTocActive] = useState(null);
@@ -124,7 +126,7 @@ const UrlTitle = ({ data, error, showSideToc, source, toc = [] }: PageData): JSX
 export async function getServerSideProps({
     params
 }: GetServerSidePropsContext<{ urlTitle: string }>): Promise<GetServerSidePropsResult<PageData>> {
-    const plugins = [DotHtmlToJsxRemark, remarkId, html, DotDecodeHtml, DotToc];
+    const plugins = [DotHtmlToJsxRemark, remarkId, html, DotDecodeHtml, DotToc, DownloadImages];
     const { DotcmsDocumentationNav, data, isHtml } = await getDocumentationData(
         params.urlTitle as string
     );

--- a/plugins/DotCodeMultiline.ts
+++ b/plugins/DotCodeMultiline.ts
@@ -7,8 +7,8 @@ interface CustomNode extends Node {
 }
 
 export default function () {
-    return function (node: CustomNode): void {
-        visit(node, 'jsx', (node: CustomNode) => {
+    return function (tree: CustomNode): void {
+        visit(tree, 'jsx', (node: CustomNode) => {
             const value = node.value;
             const preContent = new RegExp(/<pre>(.|\n)*?<\/pre>/gi);
             node.value = value.replace(preContent, (match) => {

--- a/plugins/DownloadImages.ts
+++ b/plugins/DownloadImages.ts
@@ -1,0 +1,29 @@
+import visit from 'unist-util-visit';
+import { Node } from 'unist';
+import download from 'image-downloader';
+
+interface CustomNode extends Node {
+    value: string;
+    children?: CustomNode[];
+}
+
+export default function () {
+    return async function (tree: CustomNode): Promise<void> {
+        visit(tree, 'image', (node: CustomNode) => {
+            const options = {
+                url: node.url,
+                dest: '../../public/diagram1.png' // will be saved to /path/to/dest/image.jpg
+            };
+
+            download
+                .image(options)
+                .then(({ filename }) => {
+                    console.log('Saved to', filename); // saved to /path/to/dest/image.jpg
+                })
+                .catch((err) => console.error(err));
+
+            node.url = '/diagram1.png';
+
+        });
+    };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,6 +3933,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+image-downloader@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/image-downloader/-/image-downloader-4.1.0.tgz#ce54bc675e243b24c43ca951a326416d4b7bf675"
+  integrity sha512-S6snaVMg4g08sksTb0ZUQsgQmKo0sv20jJoVtOnSbO/tVC4xcG9DydjLF5ONTKIz3e3qUPnIrMJhU9G124uIfQ==
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"


### PR DESCRIPTION
This approach use `remark` to download the image and update the url in the `node`